### PR TITLE
docs: temporarily disable Distribution Explorer until upstream mkdocs-marimo issues are resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pip install conjugate-models
 
 ## Features
 
-- [Interactive Distribution Explorer](https://williambdean.github.io/conjugate/explorer) for exploring probability distributions with real-time parameter adjustment
+- [Interactive Distribution Explorer](https://williambdean.github.io/conjugate/explorer) for exploring probability distributions with real-time parameter adjustment *(temporarily unavailable — see [#324](https://github.com/williambdean/conjugate/issues/324))*
 - **[Raw Data Workflow](https://williambdean.github.io/conjugate/examples/raw-data-workflow)** - Complete examples from raw observational data to posterior distributions with helper functions
 - **[Data Input Helper Functions](https://williambdean.github.io/conjugate/helpers)** - Extract sufficient statistics from raw observational data for all supported models
 - [Connection to Scipy Distributions](https://williambdean.github.io/conjugate/examples/scipy-connection) with `dist` attribute

--- a/docs/explorer.md
+++ b/docs/explorer.md
@@ -5,4 +5,9 @@ hide:
 ---
 # Distribution Explorer
 
-!marimo_file ./explorer.py
+> **Temporarily unavailable.** The interactive explorer is currently disabled due to rendering issues in the upstream `mkdocs-marimo` plugin:
+>
+> - Spinner never resolves on load ([mkdocs-marimo#30](https://github.com/marimo-team/mkdocs-marimo/issues/30))
+> - Distribution parameter sliders not rendering ([mkdocs-marimo#45](https://github.com/marimo-team/mkdocs-marimo/issues/45))
+>
+> The explorer will be re-enabled once these upstream issues are resolved. Progress is tracked in [issue #324](https://github.com/williambdean/conjugate/issues/324).

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ pip install conjugate-models
 
 ## Features
 
-- [Interactive Distribution Explorer](explorer.md) for exploring probability distributions with real-time parameter adjustment
+- [Interactive Distribution Explorer](explorer.md) for exploring probability distributions with real-time parameter adjustment *(temporarily unavailable — see [#324](https://github.com/williambdean/conjugate/issues/324))*
 - **[Raw Data Workflow](examples/raw-data-workflow.md)** - Complete examples from raw observational data to posterior distributions with helper functions
 - **[Data Input Helper Functions](helpers.md)** - Extract sufficient statistics from raw observational data for all supported models
 - [Connection to Scipy Distributions](examples/scipy-connection.md) with `dist` attribute


### PR DESCRIPTION
## Summary

Temporarily disables the Distribution Explorer in the docs due to upstream rendering issues in the mkdocs-marimo plugin. Keeps the nav entry but replaces the embed with a clear notice.

## Changes

- **docs/explorer.md**: Replaces the marimo embed with an informational notice linking to the two upstream bugs and tracking issue #324
- **docs/index.md**: Adds *(temporarily unavailable)* note to the explorer feature bullet
- **README.md**: Same update for sync (per AGENTS.md requirement)

## Related Issues

- Closes #306 (JOSS review: Distribution Explorer not working)
- Upstream: https://github.com/marimo-team/mkdocs-marimo/issues/30 (spinner)
- Upstream: https://github.com/marimo-team/mkdocs-marimo/issues/45 (sliders)
- Tracking re-enable: #324